### PR TITLE
S4R-9341 | update gb android tracker to support conversational origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ An example of a method you can call to send an event is the `sendViewProductEven
 
 See [Sending events](docs/sending_events.md) for more details.
 
+Note on Conversational Commerce origin:
+- To attribute autoSearch events to R2 Conversational Commerce, set `event.setOrigin(AutoSearchEvent.Origin.CONVERSATION)` and use the conversational response ID as `searchId`. See the autoSearch guide for a full example.
+
 ## Setting login status
 
 Login status describes whether the shopper is logged in or not when the event occurs. With this information set in the tracker GroupBy can anonymously track shoppers across their devices, not just anonymously track them in the Android app.

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdk 21
         targetSdk 31
         versionCode 3
-        versionName "1.4.0"
+        versionName "1.5.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/src/main/java/com/groupby/tracker/model/AutoSearchEvent.java
+++ b/src/main/java/com/groupby/tracker/model/AutoSearchEvent.java
@@ -156,7 +156,9 @@ public class AutoSearchEvent implements Parcelable {
         @SerializedName("sayt")
         SAYT("sayt"),
         @SerializedName("navigation")
-        NAVIGATION("navigation");
+        NAVIGATION("navigation"),
+        @SerializedName("conversation")
+        CONVERSATION("conversation");
         private final String value;
         private final static Map<String, AutoSearchEvent.Origin> CONSTANTS = new HashMap<String, AutoSearchEvent.Origin>();
 

--- a/src/test/java/com/groupby/tracker/GbTrackerUnitTest.java
+++ b/src/test/java/com/groupby/tracker/GbTrackerUnitTest.java
@@ -10,7 +10,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.os.Build;
@@ -24,6 +23,9 @@ import com.groupby.tracker.model.Login;
 import com.groupby.tracker.model.Metadata;
 import com.groupby.tracker.model.Price;
 import com.groupby.tracker.model.Product;
+import com.groupby.tracker.model.AutoSearchEvent;
+
+import java.util.UUID;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -113,5 +115,23 @@ public class GbTrackerUnitTest {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    @Test
+    public void autoSearchEvent_conversation_origin_serializes()
+    {
+        AutoSearchEvent event = new AutoSearchEvent();
+        UUID id = UUID.fromString("c8a16b67-d3dd-49a8-b49c-68ed18febc3f");
+        event.setSearchId(id);
+        event.setOrigin(AutoSearchEvent.Origin.CONVERSATION);
+
+        AutoSearchBeacon beacon = new AutoSearchBeacon();
+        beacon.setEvent(event);
+
+        JSON json = new JSON();
+        String payload = json.serialize(beacon);
+
+        assertTrue("payload should contain origin conversation", payload.contains("\"origin\":\"conversation\""));
+        assertTrue("payload should contain the searchId", payload.contains(id.toString()));
     }
 }


### PR DESCRIPTION
Adds "conversation" as a supported origin for autoSearch events.

This change allows tracking events originating from Conversational Commerce interactions, enabling more accurate attribution and analysis.

Includes updates to the README to document the usage of the new origin.

Relates to S4R-9341